### PR TITLE
Gracefully fail for different VAP#

### DIFF
--- a/unifirespondd.php
+++ b/unifirespondd.php
@@ -137,17 +137,24 @@ function fetchSNMP($config, $device)
 				$clients5  += $numStations;
 		}
 		
-		return [
-			"uptime" => (int)$session->get(unifiApSystemUptime),
+		if($i > 1 || $clients24 > 0 || $clients5 > 0) 
+		{
+			return [
+				"uptime" => (int)$session->get(unifiApSystemUptime),
+				
+				"rxBytes" => (int)$session->get(unifiIfRxBytes),
+				"rxPackets" => (int)$session->get(unifiIfRxPackets),
+				"txBytes" => (int)$session->get(unifiIfTxBytes),
+				"txPackets" => (int)$session->get(unifiIfTxPackets),
 
-			"rxBytes" => (int)$session->get(unifiIfRxBytes),
-			"rxPackets" => (int)$session->get(unifiIfRxPackets),
-			"txBytes" => (int)$session->get(unifiIfTxBytes),
-			"txPackets" => (int)$session->get(unifiIfTxPackets),
-
-			"clients24" => (int)$clients24,
-			"clients5"  => (int)$clients5,
-		];
+				"clients24" => (int)$clients24,
+				"clients5"  => (int)$clients5,
+			];
+		}
+		else
+		{
+			return false;
+		}
 	}
 	catch (Exception $e)
 	{

--- a/unifirespondd.php
+++ b/unifirespondd.php
@@ -121,8 +121,15 @@ function fetchSNMP($config, $device)
 
 		for ($i=1; $i < 10; $i++)
 		{ 
-			$numStations = $session->get(unifiVapNumStations . "." . $i);
-			$channel = $session->get(unifiVapChannel . "." . $i);
+			try
+			{
+				$numStations = $session->get(unifiVapNumStations . "." . $i);
+				$channel = $session->get(unifiVapChannel . "." . $i);
+			}
+			catch (Exception $e)
+			{
+				break; 	
+			}
 
 			if ($channel < 30)
 				$clients24 += $numStations; 


### PR DESCRIPTION
The current code expects 10+ virtual APs. If a lower number of VAPs is configured the loop will throw an error (`Error in packet at 'SNMPv2-SMI::enterprises.41112.1.6.1.2.1.8.*': (noSuchName) There is no such variable name in this MIB.`), go to `catch{}` and return `false`, even if all available VAPs where already counted.
Attached one way to circumvent this issue. Once a VAP can't be polled it will stop and return the sums of previous APs. The additional if should ensure to not return 0 instead of false for offline APs. This might still fail for >10 VAPs, not sure what the theoretical max is. Also there are surely better ways to fix this, but the code hasn't killed any kittens yet ;)